### PR TITLE
#FIX X-UA-Compatible in allen Templates auf Edge gesetzt

### DIFF
--- a/modx/templates/exface.AdminLteTemplate.html
+++ b/modx/templates/exface.AdminLteTemplate.html
@@ -10,6 +10,7 @@
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="mobile-web-app-capable" content="yes">
 		<meta name="page_id" content="[*id*]">
+		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		
 		<!-- Prevents browsers from sending rerferrer-headers for href, img and ajax-requests.
 		This for external media content, where requests may get filtered -->

--- a/modx/templates/exface.JEasyUiTemplate.html
+++ b/modx/templates/exface.JEasyUiTemplate.html
@@ -4,6 +4,7 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     
     <!-- Prevents browsers from sending rerferrer-headers for href, img and ajax-requests.
     This for external media content, where requests may get filtered -->

--- a/modx/templates/exface.JQueryMobileTemplate.html
+++ b/modx/templates/exface.JQueryMobileTemplate.html
@@ -8,6 +8,7 @@
 	<meta name="PalmComputingPlatform" content="true"/>
 	<meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     
     <!-- Prevents browsers from sending rerferrer-headers for href, img and ajax-requests.
     This for external media content, where requests may get filtered -->


### PR DESCRIPTION
Es trat ein Problem auf als ein IE11 eine Seite aufrief, aber im
IE7 Modus war. Dieser Tag sagt dem IE als welche Version er die Seite
rendern soll (Edge neueste).