### PR TITLE
Feature/ui page installer

### DIFF
--- a/CmsConnectors/Modx.php
+++ b/CmsConnectors/Modx.php
@@ -8,15 +8,15 @@ use exface\ModxCmsConnector\ModxCmsConnectorApp;
 use exface\Core\Factories\UiPageFactory;
 use exface\Core\CommonLogic\Filemanager;
 use exface\Core\Interfaces\AppInterface;
-use exface\Core\Exceptions\UiPageNotFoundError;
+use exface\Core\Exceptions\UiPage\UiPageNotFoundError;
 use exface\Core\Exceptions\RuntimeException;
 use exface\Core\CommonLogic\Model\UiPage;
 use exface\Core\CommonLogic\AbstractCmsConnector;
 use exface\Core\Interfaces\Log\LoggerInterface;
-use exface\Core\Exceptions\UiPageLoadingError;
-use exface\Core\Exceptions\UiPageIdNotUniqueError;
-use exface\Core\Exceptions\UiPageCreateError;
-use exface\Core\Exceptions\UiPageUpdateError;
+use exface\Core\Exceptions\UiPage\UiPageLoadingError;
+use exface\Core\Exceptions\UiPage\UiPageIdNotUniqueError;
+use exface\Core\Exceptions\UiPage\UiPageCreateError;
+use exface\Core\Exceptions\UiPage\UiPageUpdateError;
 
 class Modx extends AbstractCmsConnector
 {

--- a/CmsConnectors/Modx.php
+++ b/CmsConnectors/Modx.php
@@ -806,8 +806,22 @@ SQL;
         $siteContent = $modx->getFullTableName('site_content');
         $siteTmplvars = $modx->getFullTableName('site_tmplvars');
         $siteTmplvarContentvalues = $modx->getFullTableName('site_tmplvar_contentvalues');
+        $tvAppUidName = self::TV_APP_UID_NAME;
         
-        $result = $modx->db->select('msc.id as id', $siteContent . ' msc left join ' . $siteTmplvarContentvalues . ' mstc on msc.id = mstc.contentid left join ' . $siteTmplvars . ' mst on mstc.tmplvarid = mst.id', 'mst.name = "' . $this::TV_APP_UID_NAME . '" and mstc.value = "' . $app->getUid() . '"');
+        $query = <<<SQL
+    SELECT
+        msc.id as id
+    FROM
+        {$siteContent} msc
+        LEFT JOIN {$siteTmplvarContentvalues} mstc ON msc.id = mstc.contentid
+        LEFT JOIN {$siteTmplvars} mst ON mstc.tmplvarid = mst.id
+    WHERE
+        mst.name = "{$tvAppUidName}"
+        AND mstc.value = "{$app->getUid()}"
+        AND msc.deleted = "0"
+SQL;
+        $result = $modx->db->query($query);
+        
         $pages = [];
         while ($row = $modx->db->getRow($result)) {
             $pages[] = $this->getPageFromCms($row['id'], null, null, true);


### PR DESCRIPTION
Treten beim Erzeugen oder Updaten von Seiten Probleme auf, werden Fehler geworfen. Bisher wurden Probleme in modResource verschluckt.

Außerdem wurde ein Problem behoben, wobei die parent-Seite beim Erstellen einer Seite während des Deployment-Prozesses nicht von ModX geladen werden konnte. Dadurch wurden Seiteneigenschaften nicht vererbt. Die Ursache war, dass ModX Dokumente in einer Resource-Gruppe mit $modx->getDocument() nicht ausgibt, wenn ModX im Frontend-Modus gestartet ist. Das Dokument wird jetzt mit einer eigenen Routine aus der Datenbank geladen.
