### PR TITLE
FIX Probleme beim Deployment

### DIFF
--- a/CmsConnectors/Modx.php
+++ b/CmsConnectors/Modx.php
@@ -850,6 +850,25 @@ SQL;
     }
 
     /**
+     * Returns an associative array in which the names of the system-events are the keys
+     * and the their ids are the values.
+     * 
+     * @return string[] ['system_event_name' => 'system_event_id', ...]
+     */
+    public function getSystemEventIds()
+    {
+        global $modx;
+        
+        $result = $modx->db->select('id, name', $modx->getFullTableName('system_eventnames'));
+        $eventIds = [];
+        while ($row = $modx->db->getRow($result)) {
+            $eventIds[$row['name']] = $row['id'];
+        }
+        
+        return $eventIds;
+    }
+    
+    /**
      * Tests if the passed $username is a modx web user.
      * 
      * @param string $username

--- a/Install/sql/updates/009.add_exface_plugin_events.sql
+++ b/Install/sql/updates/009.add_exface_plugin_events.sql
@@ -1,8 +1,0 @@
-#Exface Plugin aktivieren
-UPDATE modx_site_plugins SET disabled = 0, name = 'ExFace' WHERE name = 'ExFace User Connector' OR name = 'ExFace';
-#Exface Plugin mit OnDocFormSave Event verbinden
-INSERT INTO modx_site_plugin_events (pluginid, evtid, priority) VALUES
-((SELECT msp.id FROM modx_site_plugins msp WHERE msp.name = 'ExFace User Connector' OR msp.name = 'ExFace'), (SELECT msen.id FROM modx_system_eventnames msen WHERE msen.name = 'OnWebSaveUser'), 1),
-((SELECT msp.id FROM modx_site_plugins msp WHERE msp.name = 'ExFace User Connector' OR msp.name = 'ExFace'), (SELECT msen.id FROM modx_system_eventnames msen WHERE msen.name = 'OnWebDeleteUser'), 1),
-((SELECT msp.id FROM modx_site_plugins msp WHERE msp.name = 'ExFace User Connector' OR msp.name = 'ExFace'), (SELECT msen.id FROM modx_system_eventnames msen WHERE msen.name = 'OnBeforeUserFormSave'), 1),
-((SELECT msp.id FROM modx_site_plugins msp WHERE msp.name = 'ExFace User Connector' OR msp.name = 'ExFace'), (SELECT msen.id FROM modx_system_eventnames msen WHERE msen.name = 'OnBeforeWUsrFormSave'), 1);

--- a/Install/sql/updates/011.new_alias_instead_of_page_ids.sql
+++ b/Install/sql/updates/011.new_alias_instead_of_page_ids.sql
@@ -7,7 +7,7 @@ UPDATE modx_system_settings SET setting_value = '1' WHERE setting_name = 'automa
 UPDATE modx_site_plugins SET disabled = 1 WHERE name = 'TransAlias';
 
 #Exface Plugin aktivieren
-UPDATE modx_site_plugins SET disabled = 0, name = 'ExFace' WHERE name = 'ExFace User Connector' OR name = 'ExFace';
+UPDATE modx_site_plugins SET disabled = 0 WHERE name = 'ExFace';
 
 #Im Seiten-Content page_id durch page_alias ersetzen
 UPDATE modx_site_content SET content = REPLACE(content, 'page_id', 'page_alias');

--- a/Install/sql/updates/014.refactor_modx_allow_root.sql
+++ b/Install/sql/updates/014.refactor_modx_allow_root.sql
@@ -1,0 +1,1 @@
+UPDATE modx_system_settings SET setting_value = '1' WHERE setting_name = 'udperms_allowroot';

--- a/modx/plugins/exface/plugin.exface.php
+++ b/modx/plugins/exface/plugin.exface.php
@@ -27,14 +27,14 @@ if (! isset($exface)) {
     $exface->start();
 }
 
+// Start: angepasst aus plugin.transalias.php
+require_once $modx->config['base_path'] . 'assets/plugins/transalias/transalias.class.php';
+$trans = new TransAlias($modx);
+$trans->loadTable('common', 'No');
+// Ende: angepasst aus plugin.transalias.php
+
 switch ($eventName) {
     case "OnStripAlias":
-        // Start: angepasst aus plugin.transalias.php
-        require_once $modx->config['base_path'] . 'assets/plugins/transalias/transalias.class.php';
-        $trans = new TransAlias($modx);
-        $trans->loadTable('common', 'No');
-        // Ende: angepasst aus plugin.transalias.php
-        
         $modx->event->output($trans->stripAlias($alias, 'lowercase alphanumeric', 'dash'));
         
         break;


### PR DESCRIPTION
Behebt mehrere Probleme beim Update:

Das SQL-Updateskript 009 wurde entfernt, da das Plugin zusammen mit den Zuordnungen zu den Events jetzt per Modx-Update eingespielt wird. Das Verknüpfen mit den Events macht Probleme wenn die Verknüpfung bereits existiert. Die Änderung des Namens des Plugins von "Exface User Connector" zu "Exface" macht Probleme wenn bereits ein Plugin namens "Exface" existiert.

Das SQL-Updateskript 011 wurde abgeändert aus oben genannten Gründen.

Das SQL-Updateskript 014 wurde neu hinzugefügt um die Modx-Systemeinstellung udperms_allowroot beim Update auf true zu setzen. Diese Einstellung ist nötig um beim Update Seiten im root zu erzeugen. Dies passiert seit Seiten ohne parent im root eingehängt werden.

Im exface Plugin wurde ein Fehler behoben, der beim Duplizieren einer Seite auftrat.

In Modx wurde eine neue Methode getSystemEventIds() eingefügt, welche für die Installation des Plugins im RMSInstaller benötigt wird.