### PR TITLE
Set important Modx settings in Installer

### DIFF
--- a/CmsConnectors/Modx.php
+++ b/CmsConnectors/Modx.php
@@ -659,7 +659,7 @@ SQL;
         // Parent Document Object von Modx laden.
         $parentDoc = $this->getModxDocument($parentIdCms);
         $published = $parentDoc['published'];
-        $template = $parentDoc['template'] ? $parentDoc['template'] : $modx->config['default_template'];
+        $template = $parentDoc['template'] ? $parentDoc['template'] : $this->getDefaultTemplateId();
         $docGroups = $parentDoc['document_groups'] ? explode(',', $parentDoc['document_groups']) : [];
         
         require_once ($modx->config['base_path'] . DIRECTORY_SEPARATOR . 'assets' . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'MODxAPI' . DIRECTORY_SEPARATOR . 'modResource.php');
@@ -973,7 +973,26 @@ SQL;
             unlink($lock_file_path);
         }
     }
-    
+
+    /**
+     * Returns the default template ID.
+     *
+     * @return string
+     */
+    public function getDefaultTemplateId()
+    {
+        global $modx;
+        
+        $siteTemplates = $modx->getFullTableName('site_templates');
+        $templateResult = $modx->db->select('id', $siteTemplates, 'templatename = "' . $this->getApp()->getConfig()->getOption('MODX.TEMPLATE_NAME_DEFAULT') . '"');
+        if ($modx->db->getRecordCount($templateResult) === 1) {
+            $templateRow = $modx->db->getRow($templateResult);
+            return $templateRow['id'];
+        } else {
+            return $modx->config['default_template'];
+        }
+    }
+
     /**
      * This function is a replacement for $modx->getDocument().
      * 

--- a/Config/exface.ModxCmsConnector.config.json
+++ b/Config/exface.ModxCmsConnector.config.json
@@ -19,5 +19,6 @@
 		"de_DE": "german"
 	},
 	
-	"MODX.WARNING.ON_SAVE_PAGE_IN_APP": false
+	"MODX.WARNING.ON_SAVE_PAGE_IN_APP": false,
+	"MODX.TEMPLATE_NAME_DEFAULT": "Desktop (jEasyUI)"
 }

--- a/ModxCmsConnectorInstaller.php
+++ b/ModxCmsConnectorInstaller.php
@@ -20,14 +20,48 @@ class ModxCmsConnectorInstaller extends AbstractAppInstaller
      */
     public function install($source_absolute_path)
     {
-        $result = "\n";
         // Copy index-exface.php to the root of the MODx installation
         try {
             $this->getWorkbench()->filemanager()->copy($this->getApp()->getDirectoryAbsolutePath() . DIRECTORY_SEPARATOR . 'Install' . DIRECTORY_SEPARATOR . 'index-exface.php', $this->getApp()->getModxAjaxIndexPath(), true);
-            $result .= 'Updated index-exface.php in MODx';
+            $result .= "\nUpdated index-exface.php in MODx";
         } catch (\Exception $e) {
-            $result .= 'Failed to update index-exface.php in MODx' . $e->getMessage();
+            $result .= "\nFailed to update index-exface.php in MODx" . $e->getMessage();
         }
+        
+        try {
+            $modx = $this->getWorkbench()->getApp('exface.ModxCmsConnector')->getModx();
+        } catch (\Throwable $e) {
+            $result .= "\nError getting MODx";
+            return $result;
+        }
+        
+        // Update important Modx settings.
+        try {
+            // System settings
+            $systemSettings = $modx->getFullTableName('system_settings');
+            $modx->db->update(['setting_value' => '1'], $systemSettings, 'setting_name = "friendly_urls"');
+            $modx->db->update(['setting_value' => '0'], $systemSettings, 'setting_name = "allow_duplicate_alias"');
+            $modx->db->update(['setting_value' => '1'], $systemSettings, 'setting_name = "automatic_alias"');
+            $modx->db->update(['setting_value' => '1'], $systemSettings, 'setting_name = "udperms_allowroot"');
+            
+            // Plugins
+            $sitePlugins = $modx->getFullTableName('site_plugins');
+            $modx->db->update(['disabled' => 1], $sitePlugins, 'name = "TransAlias"');
+            $modx->db->update(['disabled' => 0], $sitePlugins, 'name = "ExFace"');
+            
+            // Default template
+            $siteTemplates = $modx->getFullTableName('site_templates');
+            $templateResult = $modx->db->select('id', $siteTemplates, 'templatename = "' . $this->getApp()->getConfig()->getOption('MODX.TEMPLATE_NAME_DEFAULT') . '"');
+            if ($modx->db->getRecordCount($templateResult) === 1) {
+                $templateRow = $modx->db->getRow($templateResult);
+                $modx->db->update(['setting_value' => $templateRow['id']], $systemSettings, 'setting_name = "default_template"');
+            }
+            
+            $result .= "\nUpdated MODx settings";
+        } catch (\Throwable $e) {
+            $result .= "\nError updating MODx settings;" . $e->getMessage();
+        }
+        
         return $result;
     }
 

--- a/ModxCmsConnectorInstaller.php
+++ b/ModxCmsConnectorInstaller.php
@@ -43,19 +43,12 @@ class ModxCmsConnectorInstaller extends AbstractAppInstaller
             $modx->db->update(['setting_value' => '0'], $systemSettings, 'setting_name = "allow_duplicate_alias"');
             $modx->db->update(['setting_value' => '1'], $systemSettings, 'setting_name = "automatic_alias"');
             $modx->db->update(['setting_value' => '1'], $systemSettings, 'setting_name = "udperms_allowroot"');
+            $modx->db->update(['setting_value' => $this->getWorkbench()->getCMS()->getDefaultTemplateId()], $systemSettings, 'setting_name = "default_template"');
             
             // Plugins
             $sitePlugins = $modx->getFullTableName('site_plugins');
             $modx->db->update(['disabled' => 1], $sitePlugins, 'name = "TransAlias"');
             $modx->db->update(['disabled' => 0], $sitePlugins, 'name = "ExFace"');
-            
-            // Default template
-            $siteTemplates = $modx->getFullTableName('site_templates');
-            $templateResult = $modx->db->select('id', $siteTemplates, 'templatename = "' . $this->getApp()->getConfig()->getOption('MODX.TEMPLATE_NAME_DEFAULT') . '"');
-            if ($modx->db->getRecordCount($templateResult) === 1) {
-                $templateRow = $modx->db->getRow($templateResult);
-                $modx->db->update(['setting_value' => $templateRow['id']], $systemSettings, 'setting_name = "default_template"');
-            }
             
             $result .= "\nUpdated MODx settings";
         } catch (\Throwable $e) {

--- a/modx/plugins/exface/plugin.exface.php
+++ b/modx/plugins/exface/plugin.exface.php
@@ -28,10 +28,7 @@ if (! isset($exface)) {
         $exface = new \exface\Core\CommonLogic\Workbench();
         $exface->start();
     } catch (Throwable $e) {
-        if ($e instanceof ExceptionInterface){
-            $log_hint = ' (see log ID ' . $e->getId() . ')';
-        }
-        $modx->event->alert('Error instantiating exface;' . $e->getMessage() . ' in ' . $e->getFile() . ' at line ' . $e->getLine() . $log_hint);
+        $modx->event->alert('Error instantiating exface;' . $e->getMessage() . ' in ' . $e->getFile() . ' at line ' . $e->getLine());
         return;
     }
 }


### PR DESCRIPTION
Wichtige Modx Einstellungen werden im ModxCmsConnectorInstaller bei jedem Update wiederhergestellt.

Im Exface plugin wird keine Fehler-ID ausgegeben wenn der Fehler beim Instanziieren von Exface passiert, da der Fehler an dieser Stelle sowieso nicht geloggt wird und daher unter der angegebenen ID nicht im Log aufzufinden ist.

Beim Installieren neuer Seiten wird jetzt nicht mehr automatisch das Modx default template verwendet wenn es nicht vom parent geerbt werden kann, sondern es wird zunächst versucht das default Template, welches in der Config hinterlegt ist zu verwenden.
