### PR TITLE
FIX Fehlermeldung nicht angezeigt

### DIFF
--- a/CmsConnectors/Modx.php
+++ b/CmsConnectors/Modx.php
@@ -361,6 +361,10 @@ class Modx extends AbstractCmsConnector
     {
         global $modx;
         
+        if (is_null($modx->documentIdentifier)) {
+            return $this->getDefaultPage();
+        }
+        
         $siteContent = $modx->getFullTableName('site_content');
         
         $query = <<<SQL


### PR DESCRIPTION
Die eigentliche Fehlermeldung wurde nicht angezeigt, da Modx->loadPageCurrent() fehlschlug ($modx->documentIdentifier = null). In diesem Fall wird jetzt die defaultPage zurueckgegeben.
